### PR TITLE
0624

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.projectlombok:lombok:1.18.20'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/example/mutiparttest/Controller/TestController.java
+++ b/src/main/java/com/example/mutiparttest/Controller/TestController.java
@@ -20,22 +20,21 @@ public class TestController {
     }
 
     @PostMapping("/test")
-    public String testPost(@RequestParam("file")MultipartFile multipartFile) throws IOException{
+    public String testPost(@RequestParam("file")MultipartFile multipartFile, @RequestParam("filePath")String filePath) throws IOException{
 
         String originalFileName = multipartFile.getOriginalFilename();
-        File destination = new File("/Users/kimseojeong/Desktop/testdir/" + originalFileName);
+        File destination = new File(filePath + originalFileName);
 
         StringBuilder sb = new StringBuilder();
-
-        try{
-            String line;
+        try(
             BufferedReader br = new BufferedReader(new InputStreamReader(multipartFile.getInputStream()));
+        ){
+            String line;
             while((line = br.readLine()) != null){
                 sb.append(line);
             }
-            br.close();
-
             multipartFile.transferTo(destination);
+
         }catch(IOException e){
             return "error";
         }

--- a/src/main/java/com/example/mutiparttest/Controller/TestController.java
+++ b/src/main/java/com/example/mutiparttest/Controller/TestController.java
@@ -1,17 +1,21 @@
 package com.example.mutiparttest.Controller;
 
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import com.example.mutiparttest.domain.WavFile;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-import sun.jvm.hotspot.runtime.Bytes;
+
 
 import java.io.*;
+
 
 @RestController
 public class TestController {
 
+    private Logger logger = LoggerFactory.getLogger(TestController.class);
 
     @GetMapping("/test")
     public String testGet() {
@@ -19,22 +23,29 @@ public class TestController {
         return "TestGet";
     }
 
-    @PostMapping("/test")
-    public String testPost(@RequestParam("file")MultipartFile multipartFile, @RequestParam("filePath")String filePath) throws IOException{
 
-        String originalFileName = multipartFile.getOriginalFilename();
-        File destination = new File(filePath + originalFileName);
+    @PostMapping("/test")
+    public String testPost(@ModelAttribute WavFile wavFile) throws IOException{
+
+        WavFile file = new WavFile(wavFile.getFilePath(),wavFile.getFile());
+
+        String originalFileName = file.getFile().getOriginalFilename();
+        //파일 확장자
+        String extension = originalFileName.substring(originalFileName.lastIndexOf(".")+1);
+
+        logger.info("File Extension: "+extension);
+
+        File destination = new File(file.getFilePath() + originalFileName);
 
         StringBuilder sb = new StringBuilder();
         try(
-            BufferedReader br = new BufferedReader(new InputStreamReader(multipartFile.getInputStream()));
+            BufferedReader br = new BufferedReader(new InputStreamReader(file.getFile().getInputStream()));
         ){
             String line;
             while((line = br.readLine()) != null){
                 sb.append(line);
             }
-            multipartFile.transferTo(destination);
-
+            file.getFile().transferTo(destination);
         }catch(IOException e){
             return "error";
         }

--- a/src/main/java/com/example/mutiparttest/Controller/TestController.java
+++ b/src/main/java/com/example/mutiparttest/Controller/TestController.java
@@ -1,12 +1,17 @@
 package com.example.mutiparttest.Controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import sun.jvm.hotspot.runtime.Bytes;
+
+import java.io.*;
 
 @RestController
 public class TestController {
+
 
     @GetMapping("/test")
     public String testGet() {
@@ -15,8 +20,25 @@ public class TestController {
     }
 
     @PostMapping("/test")
-    public String testPost( ) {
+    public String testPost(@RequestParam("file")MultipartFile multipartFile) throws IOException{
 
-        return "TestPost";
+        String originalFileName = multipartFile.getOriginalFilename();
+        File destination = new File("/Users/kimseojeong/Desktop/testdir/" + originalFileName);
+
+        StringBuilder sb = new StringBuilder();
+
+        try{
+            String line;
+            BufferedReader br = new BufferedReader(new InputStreamReader(multipartFile.getInputStream()));
+            while((line = br.readLine()) != null){
+                sb.append(line);
+            }
+            br.close();
+
+            multipartFile.transferTo(destination);
+        }catch(IOException e){
+            return "error";
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/example/mutiparttest/domain/WavFile.java
+++ b/src/main/java/com/example/mutiparttest/domain/WavFile.java
@@ -1,0 +1,25 @@
+package com.example.mutiparttest.domain;
+
+import jdk.nashorn.internal.objects.annotations.Getter;
+import jdk.nashorn.internal.objects.annotations.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+
+public class WavFile {
+    private String filePath;
+    private MultipartFile file;
+
+    public WavFile(String filePath, MultipartFile file) {
+        this.filePath = filePath;
+        this.file = file;
+    }
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public MultipartFile getFile() {
+        return file;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,6 @@
 server:
   port: 9091
+  servlet:
+    multipart:
+      maxRequestSize: 100MB
+      maxFileSize: 10MB


### PR DESCRIPTION
1. Multipart 파일 사이즈 관련 옵션
- 용량 제한이 없다고 봐도 무방할것 같습니다. 스택오버플로우에서 내용중에, 400GB 파일이 업로드 됐다는 내용을 확인했습니다.
- application.yml 파일에 크기 설정하면 될것 같습니다.

2. 파일이랑 저장경로 하나의 객체로 처리
- @ReqeustBody가 JSON을 받아온다고 되어있어서, 우선 @ModelAttribute를 이용해서 구현했습니다.
(@RequestBody로는 구현이 안되는것 같습니다..)

3. 입력받는 파일 확장자 정보 로그 출력
- 우선, 파일의 확장자를 logger로 출력하게 코드 추가해놨는데 이 부분 조금더 자세하게 설명해주시면 감사하겠습니다.
